### PR TITLE
Allow multiple case-insensitive ignore prefixes

### DIFF
--- a/botbot/apps/plugins/core/logger.py
+++ b/botbot/apps/plugins/core/logger.py
@@ -7,17 +7,17 @@ import botbot_plugins.config as config
 
 
 class Config(config.BaseConfig):
-    ignore_prefix = config.Field(
+    ignore_prefixes = config.Field(
         default=["!-"],
         required=False,
         help_text="Don't log lines starting with any strings in this list"
     )
 
 
-def should_ignore_text(text, ignore_prefix):
+def should_ignore_text(text, ignore_prefixes):
     return any(
         (re.match(prefix, text, flags=re.IGNORECASE) is not None)
-        for prefix in ignore_prefix
+        for prefix in ignore_prefixes
     )
 
 
@@ -35,20 +35,20 @@ class Plugin(BasePlugin):
         # If the channel does not start with "#" that means the message
         # is part of a /query
         if line._channel_name.startswith("#"):
-            ignore_prefix = self.config['ignore_prefix']
+            ignore_prefixes = self.config['ignore_prefixes']
 
-            if ignore_prefix:
-                if not isinstance(ignore_prefix, list):
-                    ignore_prefix = [ignore_prefix]
+            if ignore_prefixes:
+                if not isinstance(ignore_prefixes, list):
+                    ignore_prefixes = [ignore_prefixes]
             else:
-                ignore_prefix = []
+                ignore_prefixes = []
 
             # Delete ACTION prefix created by /me
             text = line.text
             if text.startswith("ACTION "):
                 text = text[7:]
 
-            if not should_ignore_text(text, ignore_prefix):
+            if not should_ignore_text(text, ignore_prefixes):
                 Log.objects.create(
                     channel_id=line._channel.pk,
                     timestamp=line._received,

--- a/botbot/apps/plugins/core/logger.py
+++ b/botbot/apps/plugins/core/logger.py
@@ -45,7 +45,7 @@ class Plugin(BasePlugin):
             if text.startswith("ACTION "):
                 text = text[7:]
             
-            if should_ignore_text(text, ignore_prefix):
+            if not should_ignore_text(text, ignore_prefix):
                 Log.objects.create(
                     channel_id=line._channel.pk,
                     timestamp=line._received,

--- a/botbot/apps/plugins/core/logger.py
+++ b/botbot/apps/plugins/core/logger.py
@@ -5,6 +5,7 @@ from botbot.apps.plugins.utils import convert_nano_timestamp
 from botbot_plugins.base import BasePlugin
 import botbot_plugins.config as config
 
+
 class Config(config.BaseConfig):
     ignore_prefix = config.Field(
         default="!-",
@@ -12,12 +13,14 @@ class Config(config.BaseConfig):
         help_text="Don't log lines starting with this string"
     )
 
+
 def should_ignore_text(text, ignore_prefix):
     return any(
         (re.match(prefix, text, flags=re.IGNORECASE) is not None)
         for prefix in ignore_prefix
     )
-    
+
+
 class Plugin(BasePlugin):
     """
     Logs all activity.
@@ -33,18 +36,18 @@ class Plugin(BasePlugin):
         # is part of a /query
         if line._channel_name.startswith("#"):
             ignore_prefix = self.config['ignore_prefix']
-            
+
             if ignore_prefix:
                 if not isinstance(ignore_prefix, list):
                     ignore_prefix = [ignore_prefix]
             else:
                 ignore_prefix = []
-            
+
             # Delete ACTION prefix created by /me
             text = line.text
             if text.startswith("ACTION "):
                 text = text[7:]
-            
+
             if not should_ignore_text(text, ignore_prefix):
                 Log.objects.create(
                     channel_id=line._channel.pk,

--- a/botbot/apps/plugins/core/logger.py
+++ b/botbot/apps/plugins/core/logger.py
@@ -8,9 +8,9 @@ import botbot_plugins.config as config
 
 class Config(config.BaseConfig):
     ignore_prefix = config.Field(
-        default="!-",
+        default=["!-"],
         required=False,
-        help_text="Don't log lines starting with this string"
+        help_text="Don't log lines starting with any strings in this list"
     )
 
 

--- a/botbot/apps/plugins/core/logger.py
+++ b/botbot/apps/plugins/core/logger.py
@@ -1,3 +1,5 @@
+import re
+
 from botbot.apps.logs.models import Log
 from botbot.apps.plugins.utils import convert_nano_timestamp
 from botbot_plugins.base import BasePlugin
@@ -10,6 +12,12 @@ class Config(config.BaseConfig):
         help_text="Don't log lines starting with this string"
     )
 
+def should_ignore_text(text, ignore_prefix):
+    return any(
+        (re.match(prefix, text, flags=re.IGNORECASE) is not None)
+        for prefix in ignore_prefix
+    )
+    
 class Plugin(BasePlugin):
     """
     Logs all activity.
@@ -26,12 +34,18 @@ class Plugin(BasePlugin):
         if line._channel_name.startswith("#"):
             ignore_prefix = self.config['ignore_prefix']
             
+            if ignore_prefix:
+                if not isinstance(ignore_prefix, list):
+                    ignore_prefix = [ignore_prefix]
+            else:
+                ignore_prefix = []
+            
             # Delete ACTION prefix created by /me
             text = line.text
             if text.startswith("ACTION "):
                 text = text[7:]
             
-            if not (ignore_prefix and text.startswith(ignore_prefix)):
+            if should_ignore_text(text, ignore_prefix):
                 Log.objects.create(
                     channel_id=line._channel.pk,
                     timestamp=line._received,

--- a/botbot/apps/plugins/core/logger.py
+++ b/botbot/apps/plugins/core/logger.py
@@ -1,7 +1,6 @@
 import re
 
 from botbot.apps.logs.models import Log
-from botbot.apps.plugins.utils import convert_nano_timestamp
 from botbot_plugins.base import BasePlugin
 import botbot_plugins.config as config
 
@@ -10,7 +9,10 @@ class Config(config.BaseConfig):
     ignore_prefixes = config.Field(
         default=["!-"],
         required=False,
-        help_text="Don't log lines starting with any strings in this list"
+        help_text="""
+            Specify a list of regular expressions which match
+            the start of messages to be ignored (excluded from the logs)
+        """
     )
 
 

--- a/botbot/apps/plugins/core/logger.py
+++ b/botbot/apps/plugins/core/logger.py
@@ -16,7 +16,10 @@ class Config(config.BaseConfig):
 
 def should_ignore_text(text, ignore_prefixes):
     return any(
-        (re.match(prefix, text, flags=re.IGNORECASE) is not None)
+        (
+            prefix and
+            re.match(prefix, text, flags=re.IGNORECASE) is not None
+        )
         for prefix in ignore_prefixes
     )
 


### PR DESCRIPTION
Now performs case insensitive matching at start of message of any number of regular expressions set in the config